### PR TITLE
feat: 계좌 엔티티 및 주계좌 자동 생성 기능 구현 (#5)

### DIFF
--- a/src/main/java/com/hanaieum/server/common/dto/ApiResponse.java
+++ b/src/main/java/com/hanaieum/server/common/dto/ApiResponse.java
@@ -29,4 +29,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> ok(T data) {
         return of(HttpStatus.OK, data);
     }
+
+    public static ApiResponse<Void> ok() {
+        return of(HttpStatus.OK, "요청이 성공적으로 처리되었습니다.", null);
+    }
 }

--- a/src/main/java/com/hanaieum/server/common/exception/ErrorCode.java
+++ b/src/main/java/com/hanaieum/server/common/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND("TOKEN_001", "리프레시 토큰을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
     REFRESH_TOKEN_EXPIRED("TOKEN_002", "리프레시 토큰이 만료되었습니다", HttpStatus.UNAUTHORIZED),
 
+    // 계좌 관련 에러
+    ACCOUNT_NOT_FOUND("ACCOUNT_001", "계좌를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+
     // 입력값 검증 에러
     INVALID_INPUT_VALUE("VALIDATION_001", "입력값이 올바르지 않습니다", HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/hanaieum/server/domain/account/controller/AccountController.java
+++ b/src/main/java/com/hanaieum/server/domain/account/controller/AccountController.java
@@ -1,0 +1,34 @@
+package com.hanaieum.server.domain.account.controller;
+
+import com.hanaieum.server.common.dto.ApiResponse;
+import com.hanaieum.server.domain.account.dto.MainAccountResponse;
+import com.hanaieum.server.domain.account.service.AccountService;
+import com.hanaieum.server.domain.member.entity.Member;
+import com.hanaieum.server.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Account API", description = "계좌 관련 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @Operation(summary = "주계좌 조회", description = "사용자의 주계좌 정보를 조회합니다.")
+    @GetMapping("/main")
+    public ResponseEntity<ApiResponse<MainAccountResponse>> getMainAccount(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Member member = userDetails.getMember();
+        MainAccountResponse response = accountService.getMainAccount(member);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/account/dto/MainAccountResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/account/dto/MainAccountResponse.java
@@ -1,0 +1,29 @@
+package com.hanaieum.server.domain.account.dto;
+
+import com.hanaieum.server.domain.account.entity.Account;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MainAccountResponse {
+    private String accountNumber;
+    private String accountName;
+    private String bankName;
+    private Long balance;
+    private String accountType;
+    
+    public static MainAccountResponse of(Account account) {
+        return MainAccountResponse.builder()
+                .accountNumber(account.getNumber())
+                .accountName(account.getName())
+                .bankName(account.getBankName())
+                .balance(account.getBalance())
+                .accountType(account.getAccountType().name())
+                .build();
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/account/entity/Account.java
+++ b/src/main/java/com/hanaieum/server/domain/account/entity/Account.java
@@ -1,0 +1,46 @@
+package com.hanaieum.server.domain.account.entity;
+
+import com.hanaieum.server.common.entity.BaseEntity;
+import com.hanaieum.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "accounts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Account extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "account_number", nullable = false, unique = true, length = 20)
+    private String number;
+
+    @Column(name = "account_name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "bank_name", nullable = false, length = 50)
+    private String bankName;
+
+    @Column(name = "account_password", nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private Long balance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AccountType accountType;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+}

--- a/src/main/java/com/hanaieum/server/domain/account/entity/AccountType.java
+++ b/src/main/java/com/hanaieum/server/domain/account/entity/AccountType.java
@@ -1,0 +1,11 @@
+package com.hanaieum.server.domain.account.entity;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum AccountType {
+    MAIN("주계좌"),
+    MONEY_BOX("머니박스");
+
+    private final String description;
+}

--- a/src/main/java/com/hanaieum/server/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/account/repository/AccountRepository.java
@@ -1,0 +1,17 @@
+package com.hanaieum.server.domain.account.repository;
+
+import com.hanaieum.server.domain.account.entity.Account;
+import com.hanaieum.server.domain.account.entity.AccountType;
+import com.hanaieum.server.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    boolean existsByNumber(String number);
+    
+    Optional<Account> findByMemberAndAccountType(Member member, AccountType accountType);
+}

--- a/src/main/java/com/hanaieum/server/domain/account/service/AccountService.java
+++ b/src/main/java/com/hanaieum/server/domain/account/service/AccountService.java
@@ -1,0 +1,24 @@
+package com.hanaieum.server.domain.account.service;
+
+import com.hanaieum.server.domain.account.dto.MainAccountResponse;
+import com.hanaieum.server.domain.account.entity.Account;
+import com.hanaieum.server.domain.account.entity.AccountType;
+import com.hanaieum.server.domain.member.entity.Member;
+
+public interface AccountService {
+
+    // === 범용 계좌 생성 메서드 ===
+    Long createAccount(Member member, String accountName, String bankName, AccountType accountType, Long balance, String password);
+    Long createAccount(Long memberId, String accountName, String bankName, AccountType accountType, Long balance, String password);
+    
+    // === 주계좌 생성 메서드 ===
+    Long createMainAccount(Member member); // 연계 실행, 회원가입 -> 계좌 생성(동일 트랜잭션)
+    
+    // === 머니박스 계좌 생성 메서드 ===
+    Long createMoneyBoxAccount(Long memberId, String accountName); // 독립 실행용 (API 직접 호출)
+    Long createMoneyBoxAccount(Member member, String accountName); // 연계 실행용 (버킷리스트→머니박스 연계)
+
+    // === 계좌 조회 메서드 ===
+    MainAccountResponse getMainAccount(Member member);
+
+}

--- a/src/main/java/com/hanaieum/server/domain/account/service/AccountServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/account/service/AccountServiceImpl.java
@@ -1,0 +1,126 @@
+package com.hanaieum.server.domain.account.service;
+
+import com.hanaieum.server.common.exception.CustomException;
+import com.hanaieum.server.common.exception.ErrorCode;
+import com.hanaieum.server.domain.account.dto.MainAccountResponse;
+import com.hanaieum.server.domain.account.entity.Account;
+import com.hanaieum.server.domain.account.entity.AccountType;
+import com.hanaieum.server.domain.account.repository.AccountRepository;
+import com.hanaieum.server.domain.member.entity.Member;
+import com.hanaieum.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AccountServiceImpl implements AccountService {
+    
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    
+    @Override
+    public Long createAccount(Member member, String accountName, String bankName, AccountType accountType, Long balance, String password) {
+        // 유니크한 계좌번호 생성
+        String accountNumber = generateUniqueAccountNumber(accountType);
+        
+        // 계좌 비밀번호 암호화
+        String encodedAccountPassword = passwordEncoder.encode(password);
+        
+        Account account = Account.builder()
+                .member(member)
+                .number(accountNumber)
+                .name(accountName)
+                .bankName(bankName)
+                .password(encodedAccountPassword)
+                .balance(balance)
+                .accountType(accountType)
+                .active(true)
+                .build();
+                
+        Account savedAccount = accountRepository.save(account);
+        log.info("계좌 생성 완료 - 회원 ID: {}, 계좌번호: {}, 계좌명: {}, 은행: {}, 타입: {}", 
+                member.getId(), accountNumber, accountName, bankName, accountType);
+        
+        return savedAccount.getId();
+    }
+    
+    @Override
+    public Long createMainAccount(Member member) {
+        // 통장 이름 목록
+        List<String> accountNames = Arrays.asList(
+            "주거래하나 통장",
+            "하나 플러스 통장", 
+            "하나더넥스트 연금 통장"
+        );
+        
+        SecureRandom random = new SecureRandom();
+        String randomAccountName = accountNames.get(random.nextInt(accountNames.size()));
+        
+        // 주계좌 생성 (잔액: 7천만원, 비밀번호: 1234)
+        return createAccount(member, randomAccountName, "하나은행", AccountType.MAIN, 70000000L, "1234");
+    }
+    
+    @Override
+    public Long createAccount(Long memberId, String accountName, String bankName, AccountType accountType, Long balance, String password) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        
+        return createAccount(member, accountName, bankName, accountType, balance, password);
+    }
+    
+    @Override
+    public Long createMoneyBoxAccount(Long memberId, String accountName) {
+        // 독립 실행용 - 잔액 0원, 비밀번호 1234
+        return createAccount(memberId, accountName, "하나은행", AccountType.MONEY_BOX, 0L, "1234");
+    }
+    
+    @Override
+    public Long createMoneyBoxAccount(Member member, String accountName) {
+        // 연계 실행용 - 잔액 0원, 비밀번호 1234 
+        return createAccount(member, accountName, "하나은행", AccountType.MONEY_BOX, 0L, "1234");
+    }
+
+    // AccountType.MAIN (주계좌) : 14자리 숫자 (XXX-ZZZZZZ-ZZCYY)
+    // AccountType.MONEY_BOX (머니박스계좌) : 11자리 숫자 (XXX-YY-ZZZZZ-C)
+    private String generateUniqueAccountNumber(AccountType accountType) {
+        SecureRandom random = new SecureRandom();
+        String accountNumber;
+        
+        int length = (accountType == AccountType.MAIN) ? 14 : 11;
+        
+        do {
+            StringBuilder sb = new StringBuilder();
+            
+            // 지정된 길이만큼 랜덤 숫자 생성
+            for (int i = 0; i < length; i++) {
+                sb.append(random.nextInt(10));
+            }
+            
+            accountNumber = sb.toString();
+            
+        } while (accountRepository.existsByNumber(accountNumber));
+        
+        return accountNumber;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MainAccountResponse getMainAccount(Member member) {
+        Account mainAccount = accountRepository.findByMemberAndAccountType(member, AccountType.MAIN)
+                .orElseThrow(() -> new CustomException(ErrorCode.ACCOUNT_NOT_FOUND));
+
+        log.info("주계좌 조회 완료 - 회원 ID: {}, 계좌번호: {}", member.getId(), mainAccount.getNumber());
+        
+        return MainAccountResponse.of(mainAccount);
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hanaieum/server/domain/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-@Tag(name = "인증 API", description = "회원가입, 로그인, 로그아웃 관련 API")
+@Tag(name = "Auth API", description = "회원가입, 로그인, 로그아웃 관련 API")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/hanaieum/server/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/auth/dto/LoginRequest.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 public class LoginRequest {
 
     @NotBlank(message = "전화번호는 필수입니다")
-    @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^01\\d{9}$", message = "전화번호 형식이 올바르지 않습니다")
     private String phoneNumber;
 
     @NotBlank(message = "비밀번호는 필수입니다")

--- a/src/main/java/com/hanaieum/server/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/auth/dto/SignupRequest.java
@@ -17,7 +17,7 @@ import java.time.LocalDate;
 public class SignupRequest {
 
     @NotBlank(message = "전화번호는 필수입니다")
-    @Pattern(regexp = "^010\\d{8}$", message = "전화번호 형식이 올바르지 않습니다")
+    @Pattern(regexp = "^01\\d{9}$", message = "전화번호 형식이 올바르지 않습니다")
     private String phoneNumber;
 
     @NotBlank(message = "비밀번호는 필수입니다")

--- a/src/main/java/com/hanaieum/server/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/auth/dto/TokenResponse.java
@@ -15,14 +15,16 @@ public class TokenResponse {
     private String tokenType;
     private Long expiresIn;
     private boolean hideGroupPrompt;
+    private boolean mainAccountLinked;
     
-    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn, boolean hideGroupPrompt) {
+    public static TokenResponse of(String accessToken, String refreshToken, Long expiresIn, boolean hideGroupPrompt, boolean mainAccountLinked) {
         return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .tokenType("Bearer")
                 .expiresIn(expiresIn)
                 .hideGroupPrompt(hideGroupPrompt)
+                .mainAccountLinked(mainAccountLinked)
                 .build();
     }
 }

--- a/src/main/java/com/hanaieum/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanaieum/server/domain/member/controller/MemberController.java
@@ -1,0 +1,32 @@
+package com.hanaieum.server.domain.member.controller;
+
+import com.hanaieum.server.common.dto.ApiResponse;
+import com.hanaieum.server.domain.member.service.MemberService;
+import com.hanaieum.server.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Member API", description = "회원 관련 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "주계좌 연결", description = "사용자가 주계좌를 연결합니다.")
+    @PutMapping("/main-account/link")
+    public ResponseEntity<ApiResponse<Void>> confirmMainAccountLink(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        memberService.confirmMainAccountLink(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK, "주계좌가 연결되었습니다.", null));
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/member/entity/Gender.java
+++ b/src/main/java/com/hanaieum/server/domain/member/entity/Gender.java
@@ -1,0 +1,12 @@
+package com.hanaieum.server.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    M("남성"), F("여성");
+
+    private final String description;
+}

--- a/src/main/java/com/hanaieum/server/domain/member/entity/Member.java
+++ b/src/main/java/com/hanaieum/server/domain/member/entity/Member.java
@@ -1,6 +1,5 @@
 package com.hanaieum.server.domain.member.entity;
 
-
 import com.hanaieum.server.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,11 +30,12 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private LocalDate birthDate; // 생년월일
 
-    @Column(nullable = false, length = 1)
-    private String gender; // 성별 (M/F)
-
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private boolean isActive = true; // 활성화 여부
+    private Gender gender; // 성별 (M/F)
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true; // 활성화 여부
 
     // 그룹 안내 문구 (다시 보지 않기)
     @Column(nullable = false)
@@ -44,5 +44,9 @@ public class Member extends BaseEntity {
     // 월 생활비
     @Column(nullable = false)
     private Integer monthlyLivingCost;
+
+    // 주계좌 연결 여부
+    @Column(name = "is_main_account_linked", nullable = false)
+    private boolean mainAccountLinked = false;
 
 }

--- a/src/main/java/com/hanaieum/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanaieum/server/domain/member/service/MemberService.java
@@ -1,0 +1,6 @@
+package com.hanaieum.server.domain.member.service;
+
+public interface MemberService {
+    
+    void confirmMainAccountLink(Long memberId);
+}

--- a/src/main/java/com/hanaieum/server/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,30 @@
+package com.hanaieum.server.domain.member.service;
+
+import com.hanaieum.server.common.exception.CustomException;
+import com.hanaieum.server.common.exception.ErrorCode;
+import com.hanaieum.server.domain.member.entity.Member;
+import com.hanaieum.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void confirmMainAccountLink(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        member.setMainAccountLinked(true);
+        memberRepository.save(member);
+
+        log.info("주계좌 연결 확인 완료 - 회원 ID: {}", memberId);
+    }
+}


### PR DESCRIPTION
## 📎 Related Issue
- closes #5 

## 📝 Summary
  - Account 엔티티 작성 및 계좌 생성 기능 구현
  - 회원가입 시 주계좌 자동 생성 및 연결 상태 관리
  - 주계좌 조회/연결 확인 API 제공

## 📄 Description
### Account 엔티티 및 서비스
  - **Account 엔티티**: 계좌번호, 계좌명, 은행명, 잔액, 계좌타입, 활성화 상태
  - **AccountType ENUM**: `MAIN`(주계좌), `MONEY_BOX`(머니박스) 정의
  - **AccountService**: 계좌 생성, 주계좌/머니박스 생성 전용 메서드
  - **계좌번호 생성**: 주계좌 14자리, 머니박스 11자리 유니크 번호 생성

  ### 회원가입 플로우 연동
  - **회원가입 시**: 자동으로 주계좌 생성 (보유금액 7천만원)
  - **Member 엔티티**: `mainAccountLinked` 필드 추가 (기본값: false)
  - **TokenResponse**: 로그인 시 주계좌 연결 상태 반환(mainAccountLinked)
  - `mainAccountLinked = false`일 때 프론트에서 계좌 확인 UI 표시
  - 사용자가 계좌 정보 확인 후 연결 완료 처리

  ### API 엔드포인트
  - **`GET /api/accounts/main`**: 주계좌 정보 조회
  - **`PUT /api/members/main-account/link`**: 주계좌 연결 처리
