### PR TITLE
feat: 그룹 생성 참여 조회 기능 구현

### DIFF
--- a/src/main/java/com/hanaieum/server/common/exception/ErrorCode.java
+++ b/src/main/java/com/hanaieum/server/common/exception/ErrorCode.java
@@ -44,6 +44,10 @@ public enum ErrorCode {
     // 메시지 관련 에러
     MESSAGE_SEND_FAILURE("MESSAGE_001", "메시지 전송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    // 그룹 관련 에러
+    GROUP_NOT_FOUND("GROUP_001", "그룹을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    MEMBER_ALREADY_JOIN_GROUP("GROUP_002", "이미 참여한 그룹이 있습니다.", HttpStatus.CONFLICT),
+
     // 서버 에러
     INTERNAL_SERVER_ERROR("SERVER_001", "내부 서버 오류입니다", HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
@@ -1,4 +1,76 @@
 package com.hanaieum.server.domain.group.controller;
 
+import com.hanaieum.server.common.dto.ApiResponse;
+import com.hanaieum.server.domain.group.dto.GroupCreateRequest;
+import com.hanaieum.server.domain.group.dto.GroupJoinRequest;
+import com.hanaieum.server.domain.group.dto.GroupResponse;
+import com.hanaieum.server.domain.group.service.GroupService;
+import com.hanaieum.server.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+@Tag(name = "Group API", description = "그룹 생성, 참여, 조회 관련 API")
 public class GroupController {
+
+    private final GroupService groupService;
+
+    // --- 그룹 생성 API ---
+    @Operation(summary = "그룹 생성", description = "새로운 그룹을 생성하고 멤버를 생성된 그룹에 참여시킵니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "그룹 생성 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<GroupResponse>> createGroup(
+            @Valid @RequestBody GroupCreateRequest groupCreateRequest, // 그룹명 등을 담은 요청 DTO
+            @AuthenticationPrincipal CustomUserDetails userDetails // 그룹 생성자 (인증된 사용자) 정보
+    ) {
+        // userDetails에서 현재 로그인된 멤버의 ID를 가져와 Service로 전달
+        GroupResponse groupResponse = groupService.createGroup(groupCreateRequest, userDetails.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(HttpStatus.CREATED, "그룹 생성 성공", groupResponse));
+    }
+
+    // --- 그룹 참여 API ---
+    @Operation(summary = "그룹 참여", description = "초대 코드를 통해 기존 그룹에 참여합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "그룹 참여 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유효하지 않은 초대 코드")
+    })
+    @PostMapping("/join")
+    public ResponseEntity<ApiResponse<Void>> joinGroup(
+            @Valid @RequestBody GroupJoinRequest groupJoinRequest, // 초대 코드 등을 담은 요청 DTO
+            @AuthenticationPrincipal CustomUserDetails userDetails // 그룹에 참여하는 멤버 정보
+    ) {
+        groupService.joinGroup(groupJoinRequest, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK, "그룹 참여 성공", null)); // Void 타입으로 응답
+    }
+
+    // --- 그룹 및 그룹원 정보 조회 API ---
+    @Operation(summary = "그룹 정보 조회", description = "현재 로그인된 사용자가 속한 그룹 및 그룹원 정보를 조회합니다. 그룹에 속하지 않은 경우 null을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "그룹 정보 조회 성공"),
+    })
+    @GetMapping("/info")
+    public ResponseEntity<ApiResponse<GroupResponse>> getGroupInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails // 현재 로그인된 멤버 정보
+    ) {
+        GroupResponse groupResponse = groupService.getGroupInfo(userDetails.getId());
+        // 그룹에 속하지 않은 경우 null이 반환되므로, ApiResponse.ok(null)이 됨 (data 필드가 null)
+        return ResponseEntity.ok(ApiResponse.ok(groupResponse));
+    }
+
 }

--- a/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
@@ -69,6 +69,9 @@ public class GroupController {
             @AuthenticationPrincipal CustomUserDetails userDetails // 현재 로그인된 멤버 정보
     ) {
         GroupResponse groupResponse = groupService.getGroupInfo(userDetails.getId());
+        if(groupResponse == null) {
+            return ResponseEntity.ok(ApiResponse.of(HttpStatus.OK, "NO_GROUP", null));
+        }
         // 그룹에 속하지 않은 경우 null이 반환되므로, ApiResponse.ok(null)이 됨 (data 필드가 null)
         return ResponseEntity.ok(ApiResponse.ok(groupResponse));
     }

--- a/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/hanaieum/server/domain/group/controller/GroupController.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.controller;
+
+public class GroupController {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupCreateRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupCreateRequest.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.dto;
+
+public class GroupCreateRequest {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupCreateRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupCreateRequest.java
@@ -1,4 +1,14 @@
 package com.hanaieum.server.domain.group.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class GroupCreateRequest {
+    @NotBlank(message = "그룹명은 필수입니다.")
+    @Size(max = 20, message = "그룹명을 20자 이내로 입력해주세요.")
+    private String groupName;
 }

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupJoinRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupJoinRequest.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.dto;
+
+public class GroupJoinRequest {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupJoinRequest.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupJoinRequest.java
@@ -1,4 +1,12 @@
 package com.hanaieum.server.domain.group.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class GroupJoinRequest {
+    @NotBlank(message = "초대코드를 입력해주세요.")
+    private String inviteCode;
 }

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupResponse.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.dto;
+
+public class GroupResponse {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/dto/GroupResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/group/dto/GroupResponse.java
@@ -1,4 +1,39 @@
 package com.hanaieum.server.domain.group.dto;
 
+import com.hanaieum.server.domain.member.dto.MemberInfoResponse;
+import com.hanaieum.server.domain.group.entity.Group;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GroupResponse {
+    private Long groupId;
+    private String groupName;
+    private String inviteCode;
+    private List<MemberInfoResponse> members;
+
+    public static GroupResponse from(Group group) {
+        List<MemberInfoResponse> memberInfos = group.getMembers() != null ?
+                group.getMembers().stream()
+                        .map(member -> MemberInfoResponse.builder()
+                                .memberId(member.getId())
+                                .name(member.getName())
+                                .build())
+                        .collect(Collectors.toList()) :
+                new ArrayList<>(); // 그룹이 비어있으면 빈 리스트
+
+        return GroupResponse.builder()
+                .groupId(group.getId())
+                .groupName(group.getGroupName())
+                .inviteCode(group.getInviteCode())
+                .members(memberInfos)
+                .build();
+    }
 }

--- a/src/main/java/com/hanaieum/server/domain/group/entity/Group.java
+++ b/src/main/java/com/hanaieum/server/domain/group/entity/Group.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.entity;
+
+public class Group {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/entity/Group.java
+++ b/src/main/java/com/hanaieum/server/domain/group/entity/Group.java
@@ -1,4 +1,35 @@
 package com.hanaieum.server.domain.group.entity;
 
-public class Group {
+import com.hanaieum.server.common.entity.BaseEntity;
+import com.hanaieum.server.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "groups_table")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Group extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false, length = 20)
+    private String groupName;
+
+    @Column(nullable = false, unique = true)
+    private String inviteCode;
+
+    @Column(nullable = false)
+    private boolean isActive = true;
+
+    @OneToMany(mappedBy = "group")
+    @Builder.Default
+    private List<Member> members = new ArrayList<>();
 }

--- a/src/main/java/com/hanaieum/server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/group/repository/GroupRepository.java
@@ -1,4 +1,13 @@
 package com.hanaieum.server.domain.group.repository;
 
-public interface GroupRepository {
+import com.hanaieum.server.domain.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+    Optional<Group> findByInviteCode(String inviteCode);
+    boolean existsByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/hanaieum/server/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/group/repository/GroupRepository.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.repository;
+
+public interface GroupRepository {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/hanaieum/server/domain/group/service/GroupService.java
@@ -1,4 +1,22 @@
 package com.hanaieum.server.domain.group.service;
 
+import com.hanaieum.server.domain.group.dto.GroupCreateRequest;
+import com.hanaieum.server.domain.group.dto.GroupJoinRequest;
+import com.hanaieum.server.domain.group.dto.GroupResponse;
+import com.hanaieum.server.domain.member.entity.Member;
+
 public interface GroupService {
+
+    // 새로운 그룹 생성 후 생성한 멤버의 소속 그룹 업데이트
+    GroupResponse createGroup(GroupCreateRequest groupCreateRequest, Long memberId);
+
+    // 초대 코드로 그룹에 참여
+    void joinGroup(GroupJoinRequest groupJoinRequest, Long memberId);
+
+    // 그룹 및 그룹원 정보 조회
+    GroupResponse getGroupInfo(Long memberId);
+
+    // 초대코드 생성
+    String generateInviteCode();
+
 }

--- a/src/main/java/com/hanaieum/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/hanaieum/server/domain/group/service/GroupService.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.service;
+
+public interface GroupService {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/group/service/GroupServiceImpl.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.group.service;
+
+public class GroupServiceImpl {
+}

--- a/src/main/java/com/hanaieum/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/group/service/GroupServiceImpl.java
@@ -1,4 +1,126 @@
 package com.hanaieum.server.domain.group.service;
 
-public class GroupServiceImpl {
+import com.hanaieum.server.common.exception.CustomException;
+import com.hanaieum.server.common.exception.ErrorCode;
+import com.hanaieum.server.domain.group.dto.GroupCreateRequest;
+import com.hanaieum.server.domain.group.dto.GroupJoinRequest;
+import com.hanaieum.server.domain.group.dto.GroupResponse;
+import com.hanaieum.server.domain.group.entity.Group;
+import com.hanaieum.server.domain.group.repository.GroupRepository;
+import com.hanaieum.server.domain.member.entity.Member;
+import com.hanaieum.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupServiceImpl implements GroupService {
+
+    private final GroupRepository groupRepository;
+    private final MemberRepository memberRepository;
+
+    // 그룹 생성
+    @Override
+    public GroupResponse createGroup(GroupCreateRequest groupCreateRequest, Long memberId) {
+
+        // 멤버가 존재하는지 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 멤버가 이미 그룹에 속해 있는지 확인
+        if (member.getGroup() != null) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_JOIN_GROUP);
+        }
+
+        // 초대 코드 생성
+        String inviteCode = generateInviteCode();
+
+        // Group 엔티티 생성
+        Group newGroup = Group.builder()
+                .groupName(groupCreateRequest.getGroupName())
+                .inviteCode(inviteCode)
+                .isActive(true)
+                .build();
+
+        Group savedGroup = groupRepository.save(newGroup);
+
+        member.setGroup(savedGroup); // member의 소속 그룹 업데이트
+        member.setHideGroupPrompt(true); // 그룹프롬프트 다시 안보이도록
+        memberRepository.save(member);
+
+        savedGroup.getMembers().add(member); // group 객체의 members 리스트에 추가
+
+        log.info("그룹 생성 완료 - 그룹명: {}, 그룹 ID: {}", savedGroup.getGroupName(),savedGroup.getId());
+
+        return GroupResponse.from(savedGroup);
+    }
+
+    // 그룹 참여
+    @Override
+    public void joinGroup(GroupJoinRequest groupJoinRequest, Long memberId) {
+
+        // 멤버 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 멤버가 이미 그룹에 속해 있는지 확인
+        if (member.getGroup() != null) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_JOIN_GROUP);
+        }
+
+        // 초대 코드로 그룹 조회
+        Group targetGroup = groupRepository.findByInviteCode(groupJoinRequest.getInviteCode())
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
+
+        // 그룹 참여 멤버의 소속 그룹 업데이트
+        member.setGroup(targetGroup); // member 소속 그룹 업데이트
+        member.setHideGroupPrompt(true);
+        memberRepository.save(member);
+
+        targetGroup.getMembers().add(member); // group 객체의 members 리스트에 추가
+
+        log.info("멤버 {}가 그룹 {}에 참여했습니다.", member.getName(), targetGroup.getGroupName());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupResponse getGroupInfo(Long memberId) {
+
+        // 멤버 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 멤버가 속한 그룹 확인
+        Group group = member.getGroup();
+        if (group == null) {
+            return null;
+        }
+
+        return GroupResponse.from(group);
+    }
+
+    @Override
+    public String generateInviteCode() {
+        final String charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        final int length = 8;
+        SecureRandom rand = new SecureRandom();
+
+        String code;
+        do {
+            StringBuilder sb = new StringBuilder(length);
+            for (int i = 0; i < length; i++) {
+                sb.append(charset.charAt(rand.nextInt(charset.length())));
+            }
+            code = sb.toString();
+        } while (groupRepository.existsByInviteCode(code));
+
+        return code;
+    }
+
 }

--- a/src/main/java/com/hanaieum/server/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/member/dto/MemberInfoResponse.java
@@ -1,4 +1,13 @@
 package com.hanaieum.server.domain.member.dto;
 
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberInfoResponse {
+    private Long memberId;
+    private String name;
 }

--- a/src/main/java/com/hanaieum/server/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/hanaieum/server/domain/member/dto/MemberInfoResponse.java
@@ -1,0 +1,4 @@
+package com.hanaieum.server.domain.member.dto;
+
+public class MemberInfoResponse {
+}

--- a/src/main/java/com/hanaieum/server/domain/member/entity/Member.java
+++ b/src/main/java/com/hanaieum/server/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.hanaieum.server.domain.member.entity;
 
 import com.hanaieum.server.common.entity.BaseEntity;
+import com.hanaieum.server.domain.group.entity.Group;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -51,5 +52,9 @@ public class Member extends BaseEntity {
     // 주계좌 연결 여부
     @Column(name = "is_main_account_linked", nullable = false)
     private boolean mainAccountLinked = false;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = true)
+    private Group group; // 각 Member는 하나의 Group에만 속함
 
 }


### PR DESCRIPTION
## 📎 Related Issue
- closes #3 

## 📝 Summary
- Group 엔티티 작성 및 그룹 생성/참여/조회 기능 구현
- 그룹 생성/참여 시 Member의 hideGroupPrompt 상태 관리

## 📄 Description
### Group 엔티티 및 서비스
- Group 엔티티: 그룹명, 초대코드, 활성화 상태, 멤버리스트(mappedBy group)
- 그룹 초대 코드 생성: 8자리 영문 대소문자 유니크 문자열 생성

### 로그인 플로우 연동
- 로그인 시 : hideGroupPrompt 가 false 상태로 응답 반환
- hideGroupPrompt false 면 그룹 생성/참여 페이지
- 그룹 생성/참여시 hideGroupPrompt true로 변경
- 그룹 생성/조회시 그룹의 정보 + 해당 그룹에 참여중인 멤버 정보 리스트에 담아 반환
- 참여중인 그룹 없이 조회하면 message : NO_GROUP 응답

### API 엔드포인트
- GET /api/groups : 그룹 생성 + 해당 그룹에 참여
- POST /api/groups/join : 초대 코드로 그룹 참여
- GET /api/groups/info : 참여중인 그룹 정보(모든 멤버 리스트 포함) 조회