### PR TITLE
fix: 빈 쿠폰함 조회시 빈 List 반환하도록 수정

### DIFF
--- a/src/main/java/com/hanaieum/server/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/hanaieum/server/domain/coupon/entity/Coupon.java
@@ -24,10 +24,10 @@ public class Coupon extends BaseEntity {
     @Column(nullable = false, length = 20, name = "partner_name")
     private String partnerName;
 
-    @Column(nullable = false, length = 10, name = "coupon_name")
+    @Column(nullable = false, length = 20, name = "coupon_name")
     private String couponName;
 
-    @Column(nullable = false, length = 20, name = "description")
+    @Column(nullable = false, length = 30, name = "description")
     private String description;
 
     @Column(nullable = false, name = "validity_days")

--- a/src/main/java/com/hanaieum/server/domain/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/coupon/service/CouponServiceImpl.java
@@ -108,9 +108,9 @@ public class CouponServiceImpl implements CouponService {
     public List<CouponResponse> getCoupons(Long memberId) {
 
         List<MemberCoupon> coupons = memberCouponRepository.findAllByMember_Id(memberId);
-        if (coupons.isEmpty()) {
-            throw new CustomException(ErrorCode.COUPON_NOT_FOUND);
-        }
+//        if (coupons.isEmpty()) {
+//            throw new CustomException(ErrorCode.COUPON_NOT_FOUND);
+//        }
 
         List<CouponResponse> couponResponses = coupons
                 .stream()


### PR DESCRIPTION
## 📎 Related Issue
- closes #31 
## 📝 Summary
- 빈쿠폰함 조회시 404 대신 OK + data에 빈 리스트 반환하도록 수정

## 📄 Description
- 빈쿠폰함 조회시 404 대신 OK + data에 빈 리스트 반환하도록 수정

## 📸 Screenshot
