### PR TITLE
fix: 버킷리스트 그룹원 조회

### DIFF
--- a/src/main/java/com/hanaieum/server/domain/bucketList/controller/BucketListController.java
+++ b/src/main/java/com/hanaieum/server/domain/bucketList/controller/BucketListController.java
@@ -104,7 +104,7 @@ public class BucketListController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "그룹원의 진행중인 버킷리스트 목록 조회", description = "같은 그룹에 속한 멤버의 진행중인 공개 버킷리스트 목록을 조회합니다.")
+    @Operation(summary = "그룹원의 진행중인 버킷리스트 목록 조회", description = "같은 그룹에 속한 멤버의 진행중인 버킷리스트 목록을 조회합니다. 공개된 버킷리스트와 본인이 참여자인 비공개 버킷리스트가 조회됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "그룹원 진행중인 버킷리스트 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
@@ -119,7 +119,7 @@ public class BucketListController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @Operation(summary = "그룹원의 종료된 버킷리스트 목록 조회", description = "같은 그룹에 속한 멤버의 종료된 공개 버킷리스트 목록을 조회합니다.")
+    @Operation(summary = "그룹원의 종료된 버킷리스트 목록 조회", description = "같은 그룹에 속한 멤버의 종료된 버킷리스트 목록을 조회합니다. 공개된 버킷리스트와 본인이 참여자인 비공개 버킷리스트가 조회됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "그룹원 종료된 버킷리스트 목록 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),

--- a/src/main/java/com/hanaieum/server/domain/bucketList/repository/BucketListRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/bucketList/repository/BucketListRepository.java
@@ -25,22 +25,19 @@ public interface BucketListRepository extends JpaRepository<BucketList, Long> {
     @Query("SELECT bl FROM BucketList bl LEFT JOIN FETCH bl.participants p LEFT JOIN FETCH p.member WHERE bl.id = :id AND bl.deleted = :deleted")
     Optional<BucketList> findByIdAndDeletedWithParticipants(@Param("id") Long id, @Param("deleted") boolean deleted);
 
-    // 그룹원의 진행중인 버킷리스트 목록 조회 (공개된 것만)
-    @Query("SELECT bl FROM BucketList bl WHERE bl.member.id = :groupMemberId AND bl.status = 'IN_PROGRESS' AND bl.deleted = false AND bl.publicFlag = true ORDER BY bl.createdAt DESC")
-    List<BucketList> findByGroupMemberIdAndInProgressAndPublic(@Param("groupMemberId") Long groupMemberId);
+    // 그룹원의 진행중인 버킷리스트 목록 조회 (모든 상태)
+    @Query("SELECT bl FROM BucketList bl WHERE bl.member.id = :groupMemberId AND bl.status = 'IN_PROGRESS' AND bl.deleted = false ORDER BY bl.createdAt DESC")
+    List<BucketList> findByGroupMemberIdAndInProgress(@Param("groupMemberId") Long groupMemberId);
 
-    // 그룹원의 완료된 버킷리스트 목록 조회 (공개된 것만)
-    @Query("SELECT bl FROM BucketList bl WHERE bl.member.id = :groupMemberId AND bl.status = 'COMPLETED' AND bl.deleted = false AND bl.publicFlag = true ORDER BY bl.createdAt DESC")
-    List<BucketList> findByGroupMemberIdAndCompletedAndPublic(@Param("groupMemberId") Long groupMemberId);
+    // 그룹원의 완료된 버킷리스트 목록 조회 (모든 상태)
+    @Query("SELECT bl FROM BucketList bl WHERE bl.member.id = :groupMemberId AND bl.status = 'COMPLETED' AND bl.deleted = false ORDER BY bl.createdAt DESC")
+    List<BucketList> findByGroupMemberIdAndCompleted(@Param("groupMemberId") Long groupMemberId);
 
-    // 참여중인 버킷리스트 조회 (참여자 테이블을 통해)
-    @Query("SELECT DISTINCT bl FROM BucketList bl " +
-            "JOIN bl.participants p " +
-            "WHERE p.member.id = :memberId " +
-            "AND p.active = true " +
-            "AND bl.deleted = :deleted " +
-            "ORDER BY bl.createdAt DESC")
-    List<BucketList> findParticipatedBucketListsByMember(@Param("memberId") Long memberId, @Param("deleted") boolean deleted);
+    // 특정 멤버가 참여자인 버킷리스트 조회
+    @Query("SELECT DISTINCT bl FROM BucketList bl JOIN bl.participants p " +
+           "WHERE p.member.id = :memberId AND p.active = true AND bl.deleted = false " +
+           "ORDER BY bl.createdAt DESC")
+    List<BucketList> findByParticipantMemberId(@Param("memberId") Long memberId);
 
     // Transfer Service용 - ID로 삭제되지 않은 버킷리스트 조회
     Optional<BucketList> findByIdAndDeletedFalse(Long id);


### PR DESCRIPTION
## 📎 Related Issue
- closes #34 

## 📝 Summary
- 작업 개요

### 1. Repository 계층 개선

- **기존**: 복잡한 JOIN과 조건을 포함한 단일 쿼리
- **개선**: 단순한 데이터 조회 메서드로 분리


### 2. Service 계층에서 비즈니스 로직 처리

- **기존**: Repository에서 공개 여부 필터링
- **개선**: Service에서 접근 권한 로직 처리

## 📄 Description

### 1. Repository 계층 개선
    - `findByGroupMemberIdAndInProgress()`: 모든 진행중인 버킷리스트 조회
    - `findByGroupMemberIdAndCompleted()`: 모든 완료된 버킷리스트 조회
    - `findByParticipantMemberId()`: 참여자인 버킷리스트 조회

### 2. 서비스 계층에서 비즈니스 로직 처리
