### PR TITLE
feat: 자동이체 스케줄 및 실패 재시도 기능 구현 (#45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,6 @@ dependencies {
     implementation 'software.amazon.awssdk:s3:2.20.26'
     implementation 'software.amazon.awssdk:auth:2.20.26'
 
-    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    // https://mvnrepository.com/artifact/org.redisson/redisson-spring-boot-starter
-    // implementation 'org.redisson:redisson-spring-boot-starter:3.51.0'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferHistory.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferHistory.java
@@ -1,0 +1,62 @@
+package com.hanaieum.server.domain.autoTransfer.entity;
+
+import com.hanaieum.server.common.entity.BaseEntity;
+import com.hanaieum.server.domain.account.entity.Account;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "auto_transfer_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AutoTransferHistory extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private AutoTransferSchedule schedule; // 실행된 스케줄
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_account_id", nullable = false)
+    private Account fromAccount; // 출금 계좌 (복원 용도)
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_account_id", nullable = false)
+    private Account toAccount; // 입금 계좌 (복원 용도)
+
+    @Column(nullable = false, precision = 15, scale = 2)
+    private BigDecimal amount; // 이체금액 (스케줄 당시 금액 기록)
+
+    @Column(name = "executed_at", nullable = false)
+    private LocalDateTime executedAt; // 실제 실행된 시간
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private AutoTransferStatus status; // 실행 결과(성공/실패/재시도)
+    
+    @Column(name = "failure_reason", length = 500)
+    private String failureReason; // 실패 사유 (잔액부족 등)
+    
+    @Column(name = "retry_count", nullable = false)
+    @Builder.Default
+    private Integer retryCount = 0; // 재시도 횟수
+    
+    // 재시도 횟수 증가
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+    
+    // 상태 변경
+    public void updateStatus(AutoTransferStatus status, String failureReason) {
+        this.status = status;
+        this.failureReason = failureReason;
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferSchedule.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferSchedule.java
@@ -44,8 +44,8 @@ public class AutoTransferSchedule extends BaseEntity {
     private Boolean deleted = false; // 삭제 여부
     
     @Column(name = "valid_from", nullable = false)
-    private LocalDate validFrom; // 이 스케줄이 시작되는 달
+    private LocalDate validFrom; // 스케줄 시작일
     
     @Column(name = "valid_to")
-    private LocalDate validTo; // 이 스케줄이 끝나는 달 (null이면 현재 유효)
+    private LocalDate validTo; // 스케줄 종료일 (null이면 현재 유효)
 }

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferStatus.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/entity/AutoTransferStatus.java
@@ -1,0 +1,14 @@
+package com.hanaieum.server.domain.autoTransfer.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AutoTransferStatus {
+    SUCCESS("성공"),
+    FAILED("실패"),
+    RETRY("재시도 중");
+    
+    private final String description;
+}

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferHistoryRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferHistoryRepository.java
@@ -14,10 +14,12 @@ public interface AutoTransferHistoryRepository extends JpaRepository<AutoTransfe
     
     /**
      * 재시도 대상 실패한 이체 조회 (특정 날짜, 특정 재시도 횟수)
-     * 유연한 설계라면 추후 재시도 횟수 범위로 변경 (startOfDay, endOfDay, minRetryCount, maxRetryCount)
+     * JOIN FETCH로 History의 fromAccount, toAccount를 미리 로딩하여 LazyInitializationException 방지
      */
-    @Query("SELECT h FROM AutoTransferHistory h WHERE " +
-           "h.executedAt >= :startOfDay " +
+    @Query("SELECT h FROM AutoTransferHistory h " +
+           "JOIN FETCH h.fromAccount " +
+           "JOIN FETCH h.toAccount " +
+           "WHERE h.executedAt >= :startOfDay " +
            "AND h.executedAt < :endOfDay " +
            "AND h.status IN ('FAILED', 'RETRY') " +
            "AND h.retryCount = :retryCount " +

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferHistoryRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferHistoryRepository.java
@@ -1,0 +1,43 @@
+package com.hanaieum.server.domain.autoTransfer.repository;
+
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferHistory;
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface AutoTransferHistoryRepository extends JpaRepository<AutoTransferHistory, Long> {
+    
+    /**
+     * 재시도 대상 실패한 이체 조회 (특정 날짜, 특정 재시도 횟수)
+     * 유연한 설계라면 추후 재시도 횟수 범위로 변경 (startOfDay, endOfDay, minRetryCount, maxRetryCount)
+     */
+    @Query("SELECT h FROM AutoTransferHistory h WHERE " +
+           "h.executedAt >= :startOfDay " +
+           "AND h.executedAt < :endOfDay " +
+           "AND h.status IN ('FAILED', 'RETRY') " +
+           "AND h.retryCount = :retryCount " +
+           "ORDER BY h.executedAt ASC")
+    List<AutoTransferHistory> findFailedTransfersForRetry(
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay,
+            @Param("retryCount") Integer retryCount
+    );
+    
+    /**
+     * 특정 스케줄의 오늘 실행 이력 존재 여부 확인
+     */
+    @Query("SELECT h FROM AutoTransferHistory h WHERE " +
+           "h.schedule = :schedule " +
+           "AND h.executedAt >= :startOfDay " +
+           "AND h.executedAt < :endOfDay")
+    Optional<AutoTransferHistory> findTodayExecution(
+            @Param("schedule") AutoTransferSchedule schedule,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay
+    );
+}

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferScheduleRepository.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/repository/AutoTransferScheduleRepository.java
@@ -46,6 +46,18 @@ public interface AutoTransferScheduleRepository extends JpaRepository<AutoTransf
         @Param("moneyBoxAccount") Account moneyBoxAccount);
 
     /**
-     * 특정 이체일에 실행될 자동이체 스케줄 조회 (배치 처리용) - 추후작성
+     * 특정 이체일에 실행될 자동이체 스케줄 조회 (배치 처리용)
+     * 오늘 날짜의 "이체일"과 일치하는 스케줄
+     * 스케줄이 시작일(validFrom) 이후이며, 종료일(validTo)이 없거나 아직 종료되지 않은 스케줄
+     * 활성화되었으며 삭제 처리되지 않은 자동이체 스케줄
      */
+    @Query("SELECT ats FROM AutoTransferSchedule ats WHERE " +
+           "ats.transferDay = :targetDay AND " +
+           "ats.validFrom <= :targetDate AND " +
+           "(ats.validTo IS NULL OR ats.validTo >= :targetDate) AND " +
+           "ats.active = true AND ats.deleted = false")
+    List<AutoTransferSchedule> findSchedulesForExecution(
+        @Param("targetDate") LocalDate targetDate,
+        @Param("targetDay") Integer targetDay
+    );
 }

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/scheduler/AutoTransferScheduler.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/scheduler/AutoTransferScheduler.java
@@ -1,0 +1,78 @@
+package com.hanaieum.server.domain.autoTransfer.scheduler;
+
+import com.hanaieum.server.domain.autoTransfer.service.AutoTransferService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+/**
+ * 자동이체 스케줄러
+ * - 9시: 정규 출금 시도
+ * - 12시: 1차 재시도
+ * - 15시: 2차 재시도  
+ * - 다음날 9시: 3차 재시도 (최종)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AutoTransferScheduler {
+    
+    private final AutoTransferService autoTransferService;
+    
+    /**
+     * 매일 오전 9시: 정규 자동이체 실행 + 어제 실패분 최종 재시도
+     */
+    @Scheduled(cron = "0 0 9 * * ?", zone = "Asia/Seoul")
+    public void executeAt9AM() {
+        LocalDate today = LocalDate.now();
+        log.info("오전 9시 자동이체 실행 시작: {}", today);
+        
+        try {
+            // 1. 정규 자동이체 실행
+            autoTransferService.executeScheduledTransfers(today);
+
+            // 2. 어제 실패분 최종 재시도 (retryCount = 2)
+            LocalDate yesterday = today.minusDays(1);
+            autoTransferService.retryFailedTransfers(yesterday, 2);
+            
+            log.info("오전 9시 자동이체 실행 완료: {}", today);
+        } catch (Exception e) {
+            log.error("오전 9시 자동이체 실행 중 예외 발생: {}", e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 매일 오후 12시: 당일 실패분 1차 재시도
+     */
+    @Scheduled(cron = "0 0 12 * * ?", zone = "Asia/Seoul")
+    public void retryAt12PM() {
+        LocalDate today = LocalDate.now();
+        log.info("오후 12시 1차 재시도 시작: {}", today);
+        
+        try {
+            autoTransferService.retryFailedTransfers(today, 0);
+            log.info("오후 12시 1차 재시도 완료: {}", today);
+        } catch (Exception e) {
+            log.error("오후 12시 1차 재시도 중 예외 발생: {}", e.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 매일 오후 3시: 당일 실패분 2차 재시도
+     */
+    @Scheduled(cron = "0 0 15 * * ?", zone = "Asia/Seoul")
+    public void retryAt3PM() {
+        LocalDate today = LocalDate.now();
+        log.info("오후 3시 2차 재시도 시작: {}", today);
+        
+        try {
+            autoTransferService.retryFailedTransfers(today, 1);
+            log.info("오후 3시 2차 재시도 완료: {}", today);
+        } catch (Exception e) {
+            log.error("오후 3시 2차 재시도 중 예외 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/service/AutoTransferService.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/service/AutoTransferService.java
@@ -1,0 +1,30 @@
+package com.hanaieum.server.domain.autoTransfer.service;
+
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferHistory;
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferSchedule;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AutoTransferService {
+    
+    /**
+     * 특정 날짜에 실행해야 하는 자동이체 처리
+     */
+    void executeScheduledTransfers(LocalDate targetDate);
+    
+    /**
+     * 단일 스케줄 실행
+     */
+    AutoTransferHistory executeTransfer(AutoTransferSchedule schedule);
+    
+    /**
+     * 특정 날짜 + 재시도 횟수의 실패한 자동이체 재시도 처리
+     */
+    void retryFailedTransfers(LocalDate targetDate, Integer retryCount);
+    
+    /**
+     * 특정 날짜의 실행 대상 스케줄 조회
+     */
+    List<AutoTransferSchedule> getSchedulesToExecute(LocalDate targetDate);
+}

--- a/src/main/java/com/hanaieum/server/domain/autoTransfer/service/AutoTransferServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/autoTransfer/service/AutoTransferServiceImpl.java
@@ -1,0 +1,211 @@
+package com.hanaieum.server.domain.autoTransfer.service;
+
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferHistory;
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferSchedule;
+import com.hanaieum.server.domain.autoTransfer.entity.AutoTransferStatus;
+import com.hanaieum.server.domain.autoTransfer.repository.AutoTransferHistoryRepository;
+import com.hanaieum.server.domain.autoTransfer.repository.AutoTransferScheduleRepository;
+import com.hanaieum.server.domain.transfer.service.TransferService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AutoTransferServiceImpl implements AutoTransferService {
+    
+    private final AutoTransferScheduleRepository scheduleRepository;
+    private final AutoTransferHistoryRepository historyRepository;
+    private final TransferService transferService;
+    
+    @Override
+    public void executeScheduledTransfers(LocalDate targetDate) {
+        log.info("자동이체 실행 시작: targetDate={}", targetDate);
+        
+        List<AutoTransferSchedule> schedules = getSchedulesToExecute(targetDate);
+        log.info("실행 대상 스케줄 개수: {}", schedules.size());
+        
+        int successCount = 0;
+        int failureCount = 0;
+        
+        for (AutoTransferSchedule schedule : schedules) {
+            try {
+                // 오늘 이미 실행된 스케줄인지 확인
+                if (isAlreadyExecutedToday(schedule, targetDate)) {
+                    log.info("스케줄 {}은 이미 오늘 실행되었습니다", schedule.getId());
+                    continue;
+                }
+                
+                AutoTransferHistory history = executeTransfer(schedule);
+                if (history.getStatus() == AutoTransferStatus.SUCCESS) {
+                    successCount++;
+                } else {
+                    failureCount++;
+                }
+                
+            } catch (Exception e) {
+                log.error("자동이체 실행 중 예외 발생: scheduleId={}, error={}",
+                         schedule.getId(), e.getMessage(), e);
+                failureCount++;
+            }
+        }
+        
+        log.info("자동이체 실행 완료: 성공={}, 실패={}", successCount, failureCount);
+    }
+    
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public AutoTransferHistory executeTransfer(AutoTransferSchedule schedule) {
+        log.info("자동이체 실행: scheduleId={}, fromAccountId={}, toAccountId={}, amount={}", 
+                schedule.getId(), schedule.getFromAccount().getId(), 
+                schedule.getToAccount().getId(), schedule.getAmount());
+        
+        LocalDateTime executionTime = LocalDateTime.now();
+        
+        try {
+            // TransferService를 통한 실제 이체 실행
+            executeActualTransfer(schedule);
+            
+            // 성공 이력 기록
+            AutoTransferHistory history = AutoTransferHistory.builder()
+                    .schedule(schedule)
+                    .fromAccount(schedule.getFromAccount())
+                    .toAccount(schedule.getToAccount())
+                    .amount(schedule.getAmount())
+                    .executedAt(executionTime)
+                    .status(AutoTransferStatus.SUCCESS)
+                    .failureReason(null)
+                    .retryCount(0)
+                    .build();
+            
+            AutoTransferHistory savedHistory = historyRepository.save(history);
+            log.info("자동이체 성공: historyId={}", savedHistory.getId());
+            
+            return savedHistory;
+            
+        } catch (Exception e) {
+            log.error("자동이체 실패: scheduleId={}, error={}", schedule.getId(), e.getMessage(), e);
+            
+            // 실패 이력 기록
+            AutoTransferHistory history = AutoTransferHistory.builder()
+                    .schedule(schedule)
+                    .fromAccount(schedule.getFromAccount())
+                    .toAccount(schedule.getToAccount())
+                    .amount(schedule.getAmount())
+                    .executedAt(executionTime)
+                    .status(AutoTransferStatus.FAILED)
+                    .failureReason(e.getMessage())
+                    .retryCount(0)
+                    .build();
+            
+            return historyRepository.save(history);
+        }
+    }
+    
+    @Override
+    public void retryFailedTransfers(LocalDate targetDate, Integer retryCount) {
+        log.info("자동이체 재시도 시작 - 날짜: {}, 재시도 횟수: {}", targetDate, retryCount);
+        
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.plusDays(1).atStartOfDay();
+        
+        List<AutoTransferHistory> failedTransfers = 
+            historyRepository.findFailedTransfersForRetry(startOfDay, endOfDay, retryCount);
+        
+        log.info("재시도 대상: {}건", failedTransfers.size());
+        
+        int successCount = 0;
+        int failedCount = 0;
+        
+        for (AutoTransferHistory history : failedTransfers) {
+            try {
+                retryOneHistory(history);
+                successCount++;
+            } catch (Exception e) {
+                failedCount++;
+                log.error("자동이체 재시도 처리 중 예외 발생: historyId={}, error={}", 
+                         history.getId(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("자동이체 재시도 완료 - 날짜: {}, 성공: {}건, 실패: {}건", targetDate, successCount, failedCount);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<AutoTransferSchedule> getSchedulesToExecute(LocalDate targetDate) {
+        int targetDay = targetDate.getDayOfMonth();
+        return scheduleRepository.findSchedulesForExecution(targetDate, targetDay);
+    }
+    
+    /**
+     * 개별 재시도 처리 (독립 트랜잭션)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void retryOneHistory(AutoTransferHistory history) {
+        log.debug("자동이체 재시도 - History ID: {}, Schedule ID: {}, Retry Count: {}", 
+                 history.getId(), history.getSchedule().getId(), history.getRetryCount());
+        
+        try {
+            // 이체 재실행
+            executeActualTransfer(history.getSchedule());
+            
+            // 성공 처리
+            history.updateStatus(AutoTransferStatus.SUCCESS, null);
+            log.info("자동이체 재시도 성공 - History ID: {}", history.getId());
+            
+        } catch (Exception e) {
+            // 재시도 횟수 증가
+            history.incrementRetryCount();
+            
+            // 최종 실패 여부 판단 (3차 재시도 후 실패)
+            if (history.getRetryCount() >= 3) {
+                history.updateStatus(AutoTransferStatus.FAILED, e.getMessage());
+                log.warn("자동이체 최종 실패 - History ID: {}, 사유: {}", 
+                        history.getId(), e.getMessage());
+            } else {
+                history.updateStatus(AutoTransferStatus.RETRY, e.getMessage());
+                log.warn("자동이체 재시도 실패 - History ID: {}, Retry Count: {}, 사유: {}", 
+                        history.getId(), history.getRetryCount(), e.getMessage());
+            }
+            
+            // 실패 시에도 예외를 다시 던져서 상위에서 실패 카운트 처리
+            throw e;
+        }
+    }
+    
+    /**
+     * 실제 이체 실행 로직
+     */
+    private void executeActualTransfer(AutoTransferSchedule schedule) {
+        transferService.executeAutoTransfer(
+            schedule.getFromAccount().getId(),
+            schedule.getToAccount().getId(),
+            schedule.getAmount(),
+            schedule.getId()
+        );
+    }
+    
+    /**
+     * 오늘 이미 실행된 스케줄인지 확인
+     */
+    private boolean isAlreadyExecutedToday(AutoTransferSchedule schedule, LocalDate targetDate) {
+        LocalDateTime startOfDay = targetDate.atStartOfDay();
+        LocalDateTime endOfDay = targetDate.plusDays(1).atStartOfDay();
+        
+        Optional<AutoTransferHistory> todayExecution = 
+            historyRepository.findTodayExecution(schedule, startOfDay, endOfDay);
+        
+        return todayExecution.isPresent() && 
+               todayExecution.get().getStatus() == AutoTransferStatus.SUCCESS;
+    }
+}

--- a/src/main/java/com/hanaieum/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanaieum/server/domain/member/service/MemberService.java
@@ -10,8 +10,8 @@ public interface MemberService {
     void hideGroupPrompt(Long memberId);
     
     MemberMypageResponse getMypageInfo(Long memberId);
-    
-    MemberMypageResponse updateMonthlyLivingCost(Long memberId, Integer monthlyLivingCost);
-    
+
     MonthlyLivingCostResponse getMonthlyLivingCost(Long memberId);
+
+    MemberMypageResponse updateMonthlyLivingCost(Long memberId, Integer monthlyLivingCost);
 }

--- a/src/main/java/com/hanaieum/server/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/member/service/MemberServiceImpl.java
@@ -14,12 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
 
     @Override
+    @Transactional
     public void confirmMainAccountLink(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -31,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public void hideGroupPrompt(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -42,7 +44,6 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MemberMypageResponse getMypageInfo(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -52,6 +53,16 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public MonthlyLivingCostResponse getMonthlyLivingCost(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        log.info("월 생활비 조회 - 회원 ID: {}", memberId);
+        return MonthlyLivingCostResponse.of(member);
+    }
+
+    @Override
+    @Transactional
     public MemberMypageResponse updateMonthlyLivingCost(Long memberId, Integer monthlyLivingCost) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
@@ -63,13 +74,4 @@ public class MemberServiceImpl implements MemberService {
         return MemberMypageResponse.of(member);
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public MonthlyLivingCostResponse getMonthlyLivingCost(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-
-        log.info("월 생활비 조회 - 회원 ID: {}", memberId);
-        return MonthlyLivingCostResponse.of(member);
-    }
 }

--- a/src/main/java/com/hanaieum/server/domain/moneyBox/service/MoneyBoxServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/moneyBox/service/MoneyBoxServiceImpl.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional
+@Transactional(readOnly = true)
 public class MoneyBoxServiceImpl implements MoneyBoxService {
 
     private final AccountRepository accountRepository;
@@ -33,6 +33,7 @@ public class MoneyBoxServiceImpl implements MoneyBoxService {
     private final AccountService accountService;
 
     @Override
+    @Transactional
     public MoneyBoxUpdateResponse updateMoneyBox(Member member, Long accountId, MoneyBoxUpdateRequest request) {
         
         // 계좌 조회 및 검증
@@ -67,7 +68,6 @@ public class MoneyBoxServiceImpl implements MoneyBoxService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<MoneyBoxResponse> getMyMoneyBoxList(Member member) {
         // 사용자의 모든 MONEY_BOX 타입 계좌 조회
         List<Account> moneyBoxAccounts = accountRepository.findAllByMemberAndAccountTypeAndDeletedFalse(
@@ -87,7 +87,6 @@ public class MoneyBoxServiceImpl implements MoneyBoxService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MoneyBoxInfoResponse getMoneyBoxInfo(Member member, Long boxId) {
         // 머니박스 계좌 조회 및 검증
         Account account = accountRepository.findByIdAndDeletedFalse(boxId)
@@ -119,7 +118,6 @@ public class MoneyBoxServiceImpl implements MoneyBoxService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public MoneyBoxUpdateResponse getMoneyBoxForEdit(Member member, Long boxId) {
         // 머니박스 계좌 조회 및 검증
         Account account = accountRepository.findByIdAndDeletedFalse(boxId)

--- a/src/main/java/com/hanaieum/server/domain/transaction/service/TransactionServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/transaction/service/TransactionServiceImpl.java
@@ -19,13 +19,14 @@ import java.math.BigDecimal;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class TransactionServiceImpl implements TransactionService {
 
     private final TransactionRepository transactionRepository;
     private final AccountService accountService;
 
     @Override
+    @Transactional
     public void recordTransfer(Account fromAccount, Account toAccount, BigDecimal amount,
                                ReferenceType referenceType, String description, Long referenceId) {
 
@@ -64,6 +65,7 @@ public class TransactionServiceImpl implements TransactionService {
     }
 
     @Override
+    @Transactional
     public void recordDeposit(Account toAccount, BigDecimal amount, Long counterpartyAccountId,
                              String counterpartyName, ReferenceType referenceType, String description, Long referenceId) {
 
@@ -87,7 +89,6 @@ public class TransactionServiceImpl implements TransactionService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Page<TransactionResponse> getTransactionsByAccountId(Long memberId, Long accountId, Pageable pageable) {
 
         // 계좌 소유권 검증

--- a/src/main/java/com/hanaieum/server/domain/transfer/service/TransferService.java
+++ b/src/main/java/com/hanaieum/server/domain/transfer/service/TransferService.java
@@ -9,8 +9,9 @@ public interface TransferService {
     
     void sponsorBucket(Long sponsorMemberId, Long bucketId, BigDecimal amount, String password);
 
-    void payInterest(Long memberId, BigDecimal interestAmount, Long bucketListId);
+    void executeAutoTransfer(Long fromAccountId, Long toAccountId, BigDecimal amount, Long scheduleId);
 
     BigDecimal withdrawAllFromMoneyBox(Long memberId, Long moneyBoxAccountId, ReferenceType referenceType, Long referenceId);
 
+    void payInterest(Long memberId, BigDecimal interestAmount, Long bucketListId);
 }

--- a/src/main/java/com/hanaieum/server/domain/transfer/service/TransferServiceImpl.java
+++ b/src/main/java/com/hanaieum/server/domain/transfer/service/TransferServiceImpl.java
@@ -69,6 +69,18 @@ public class TransferServiceImpl implements TransferService {
     }
 
     @Override
+    public void executeAutoTransfer(Long fromAccountId, Long toAccountId, BigDecimal amount, Long scheduleId) {
+        log.info("자동이체 실행 - 출금계좌: {}, 입금계좌: {}, 금액: {}, 스케줄ID: {}", 
+                fromAccountId, toAccountId, amount, scheduleId);
+
+        // 자동이체는 비밀번호 검증 없이 실행, scheduleId를 referenceId로 전달
+        executeTransfer(fromAccountId, toAccountId, amount, ReferenceType.AUTO_TRANSFER, scheduleId);
+
+        log.info("자동이체 실행 완료 - 출금계좌: {}, 입금계좌: {}, 금액: {}, 스케줄ID: {}", 
+                fromAccountId, toAccountId, amount, scheduleId);
+    }
+
+    @Override
     public BigDecimal withdrawAllFromMoneyBox(Long memberId, Long moneyBoxAccountId, ReferenceType referenceType, Long referenceId) {
         log.info("머니박스 전액 인출 시작 - 회원 ID: {}, 머니박스: {}, 참조: {}", memberId, moneyBoxAccountId, referenceType);
 


### PR DESCRIPTION
## 📎 Related Issue
- closes #45 

## 📝 Summary
- 자동이체 정규 실행: 매일 오전 9시
- 자동이체 실패 건 재시도: 12시, 15시, 익일 9시
- 실행 이력(AutoTransferHistory)을 통해 중복 실행을 방지, 실패 시 최대 3회까지 재시도 가능

## 📄 Description

### Entity & Enum

- `AutoTransferHistory` 엔티티 추가
    - 스케줄, 출금/입금 계좌, 금액, 실행 시각, 상태, 실패 사유, 재시도 횟수 저장
- `AutoTransferStatus` Enum 정의 (`SUCCESS`, `FAILED`, `RETRY`)

### Repository

- `AutoTransferHistoryRepository`
    - 특정 날짜/재시도 횟수 기준으로 실패 이력 조회 (`findFailedTransfersForRetry`)
    - 특정 스케줄의 당일 실행 여부 조회 (`findTodayExecution`)
- `AutoTransferScheduleRepository`
    - 실행 대상 스케줄 조회 (`findSchedulesForExecution`)

### Service

- `AutoTransferServiceImpl`
    - `executeScheduledTransfers()`: 당일 실행 대상 스케줄 실행
    - `executeTransfer()`: 단건 스케줄 실행 (독립 트랜잭션)
    - `retryFailedTransfers()`: 실패 건 일괄 재시도
    - `retryOneHistory()`: 실패 이력 개별 재시도 (최대 3회)
    - 실행 결과는 `AutoTransferHistory`에 기록하고 상태(`SUCCESS/FAILED/RETRY`) 업데이트

### Scheduler

- `AutoTransferScheduler`
    - 오전 9시: 당일 정규 실행 + 어제 실패분 최종 재시도 (retryCount=2)
    - 오후 12시: 당일 실패분 1차 재시도 (retryCount=0)
    - 오후 3시: 당일 실패분 2차 재시도 (retryCount=1)
